### PR TITLE
Bugfix in Couriers url construction

### DIFF
--- a/src/AfterShip/Couriers.php
+++ b/src/AfterShip/Couriers.php
@@ -22,7 +22,7 @@ class Couriers extends Request
 
     public function get()
     {
-        return $this->send('/couriers', 'GET');
+        return $this->send('couriers', 'GET');
     }
 
     public function detect($tracking_number)
@@ -31,6 +31,6 @@ class Couriers extends Request
             throw new \Exception('Tracking number cannot be empty');
         }
 
-        return $this->send('/couriers/detect/'.$tracking_number, 'GET');
+        return $this->send('couriers/detect/'.$tracking_number, 'GET');
     }
 }


### PR DESCRIPTION
An extra slash was being added to the courier urls. This was causing AfterShip to reject the request.
